### PR TITLE
Suggested resolution for naming conflict

### DIFF
--- a/ext/SplitLauncher.pyx
+++ b/ext/SplitLauncher.pyx
@@ -1,8 +1,8 @@
 cdef extern from "SplitWav.h":
-		int split(char *infilearg, char *outfilearg, int t, int hasDt)
+		int split_wav(char *infilearg, char *outfilearg, int t, int hasDt)
 		
 def launchCython(infile_c, outfile_c, cutLen, wavHasDt):
-		succ = split(infile_c, outfile_c, cutLen, wavHasDt)
+		succ = split_wav(infile_c, outfile_c, cutLen, wavHasDt)
 		return(succ)
 
 

--- a/ext/SplitWav.c
+++ b/ext/SplitWav.c
@@ -14,7 +14,9 @@
 // USAGE: ./SplitWav infile.wav outfile.wav maxSeconds
 
 // to deal with windows requirements for .pyds
+#ifdef _WIN32
 void PyInit_SplitWav() {}
+#endif
 
 // I HATE WINDOWS
 // this is handwritten strptime(s, "%Y%m%d_%H%M%S", &timestruc)
@@ -59,7 +61,7 @@ int strptime2(char *s, char *format, struct tm *temp){
 }
 
 
-int split(char *infilearg, char *outfilearg, int t, int hasDt){
+int split_wav(char *infilearg, char *outfilearg, int t, int hasDt){
         // parse arguments
         FILE *infile, *outfile;
 		

--- a/ext/__init__.py
+++ b/ext/__init__.py
@@ -1,0 +1,1 @@
+from .ce_denoise import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ scipy==1.15.3
 scikit-image==0.25.2
 soundfile==0.13.1
 tensorflow==2.19.0
+transformers
 PyQt6==6.9.0
 
 # For those without AVX2 support:


### PR DESCRIPTION
Nomenclature conflict prevents build on windows >> renamed split to split_wav 
Also, missing from requirements: transformers